### PR TITLE
Ambuc patch 1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,20 +1,13 @@
-name: Format python code
+name: Lint
 on: push
 jobs:
   autopep8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Source
+        uses: actions/checkout@v2
       - name: autopep8
-        uses: peter-evans/autopep8@v1
-        with:
-          args: --recursive --in-place --aggressive --aggressive .
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: autopep8 action fixes
-          title: Fixes by autopep8 action
-          body: This is an auto-generated PR with fixes by autopep8.
-          labels: autopep8, automated pr
-          reviewers: ambuc
-          branch: autopep8-patches
+        # Prints a diff if autopep8 wants to make changes. Not so aggressive as to propose a PR, though.
+        run: |
+          python3 -m pip install --upgrade autopep8
+          python3 -m autopep8 --exit-code --diff --recursive --aggressive --aggressive .

--- a/README.md
+++ b/README.md
@@ -10,41 +10,12 @@ Example:
 (Left-to-right: (a) source left-hand component, (b) source right-hand component,
 (c) expected composition, (d) predicted composition, (e) c/d difference)
 
-## Quickstart
-
-* First clone this repo. 
-
-  ```bash
-  git clone git@github.com:google/autocjk.git
-  ```
-
-* You will also need to install [git-lfs](https://git-lfs.github.com/) to
-  download the large generator files.
-
-  ```bash
-  sudo apt-get install git-lfs
-  git lfs pull
-  ```
-
-* You will also need `pip3>=19.0` in order to install `tensorflow>=2.3.0`. 
-  This part is finicky and should be done manually, not through bazel pip 
-  requirements.
-
-  ```bash
-  pip3 install --upgrade pip
-  pip3 install "tensorflow>=2.3.0"
-  ```
-
-* You will also need
-  [Harfbuzz](https://harfbuzz.github.io/install-harfbuzz.html) for font shaping.
-
-  ```bash
-  sudo apt-get install libharfbuzz-bin
-  ```
-
 ### How do I generate a new character?
 
-For example, given a font at `~/Downloads/font.otf`, we can render `⿰市來` and
+First install the project and its dependencies. See platform-specific instructions
+on the [wiki](https://github.com/google/autocjk/wiki).
+
+Given a font at `~/Downloads/font.otf`, we can render `⿰市來` and
 write the generated image to `/tmp/out.png` with:
 
 ```


### PR DESCRIPTION
Oops, I meant to take out https://github.com/ambuc/autocjk/pull/5 against google/autocjk/main instead.

This just points to the [wiki](https://github.com/google/autocjk/wiki) from the homepage.

It also updates `main.yml` to lint for autopep8.