### PR TITLE
Update requirements with scipy, cython, versionless Pillow and tensorflow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-Pillow==8.2.0
+Pillow
 PyICU
 absl-py
 backcall
+cython
 decorator
 fonttools
 imagehash
@@ -13,6 +14,7 @@ numpy
 pickleshare
 prompt_toolkit
 protobuf 
-tensorflow >= 2.3.0
+scipy
+tensorflow 
 traitlets
 wcwidth


### PR DESCRIPTION
Found that these were necessary on a fresh install.