### PR TITLE
model_lib.Model accepts arbitrary number of input images.

### DIFF
--- a/src/evaluate_font.py
+++ b/src/evaluate_font.py
@@ -125,7 +125,8 @@ def calculate_wrongness(generator,
         imageutils.write_character(_FONT_PATH.value, character,
                                    actual_file.name)
 
-        imageutils.predict_from_paths(generator, lhs_file.name, rhs_file.name,
+        imageutils.predict_from_paths(generator,
+                                      [lhs_file.name, rhs_file.name],
                                       predicted_file.name)
 
         if out_dir:

--- a/src/evaluate_glyphwiki.py
+++ b/src/evaluate_glyphwiki.py
@@ -161,7 +161,8 @@ def calculate_wrongness(generator,
                         suffix=".png") as actual_file:
         _download_from_glyphwiki(lhs, lhs_file.name)
         _download_from_glyphwiki(rhs, rhs_file.name)
-        imageutils.predict_from_paths(generator, lhs_file.name, rhs_file.name,
+        imageutils.predict_from_paths(generator,
+                                      [lhs_file.name, rhs_file.name],
                                       predicted_file.name)
         _download_from_glyphwiki(character, actual_file.name)
 

--- a/src/main.py
+++ b/src/main.py
@@ -67,7 +67,7 @@ def main(argv: Sequence[str]) -> None:
 
     # Load in the generator,
     generator = tf.keras.models.load_model(generator_lib.PATH_TO_GENERATOR)
-    imageutils.predict(generator, _FONT_PATH.value, lhs, rhs, _OUT.value)
+    imageutils.predict(generator, _FONT_PATH.value, [lhs, rhs], _OUT.value)
 
 
 if __name__ == "__main__":

--- a/src/model.py
+++ b/src/model.py
@@ -137,114 +137,6 @@ def _upsample(filters: int,
     return result
 
 
-def _make_generator() -> tf.keras.Model:
-    """Creates a generator.
-
-  99% of this is copied directly from
-  https://www.tensorflow.org/tutorials/generative/pix2pix#build_the_generator,
-  except for the input shape (now two channels, two greyscale images instead of
-  one RGB image) and output shape (one channel, one greyscale image instead of
-  one RGB image).
-
-  Returns:
-    a tf.keras.Model which returns a 256x256x1 tensor.
-  """
-    inputs = tf.keras.layers.Input(shape=[256, 256, 2])
-
-    up_stack = [
-        _upsample(512, 4, apply_dropout=True),  # (bs, 2, 2, 1024)
-        _upsample(512, 4, apply_dropout=True),  # (bs, 4, 4, 1024)
-        _upsample(512, 4, apply_dropout=True),  # (bs, 8, 8, 1024)
-        _upsample(512, 4),  # (bs, 16, 16, 1024)
-        _upsample(256, 4),  # (bs, 32, 32, 512)
-        _upsample(128, 4),  # (bs, 64, 64, 256)
-        _upsample(64, 4),  # (bs, 128, 128, 128)
-    ]
-
-    x = inputs
-
-    skips = []
-    for down in [
-            _downsample(64, 4, apply_batchnorm=False),  # (bs, 128, 128, 64)
-            _downsample(128, 4),  # (bs, 64, 64, 128)
-            _downsample(256, 4),  # (bs, 32, 32, 256)
-            _downsample(512, 4),  # (bs, 16, 16, 512)
-            _downsample(512, 4),  # (bs, 8, 8, 512)
-            _downsample(512, 4),  # (bs, 4, 4, 512)
-            _downsample(512, 4),  # (bs, 2, 2, 512)
-            _downsample(512, 4),  # (bs, 1, 1, 512)
-    ]:
-        x = down(x)
-        skips.append(x)
-
-    skips = reversed(skips[:-1])
-
-    # Upsampling and establishing the skip connections
-    for up, skip in zip(up_stack, skips):
-        x = up(x)
-        x = tf.keras.layers.Concatenate()([x, skip])
-
-    last = tf.keras.layers.Conv2DTranspose(
-        1,  # one output channel, i.e. greyscale
-        4,
-        strides=2,
-        padding='same',
-        kernel_initializer=tf.random_normal_initializer(0., 0.02),
-        activation='tanh')  # (bs, 256, 256, 3)
-
-    x = last(x)
-
-    return tf.keras.Model(inputs=inputs, outputs=x)
-
-
-def _make_discriminator() -> tf.keras.Model:
-    """Returns a discriminator.
-
-  This is 99% the same as
-  https://www.tensorflow.org/tutorials/generative/pix2pix#build_the_discriminator,
-  except that the shape of the input and output tensors are different.
-
-  Returns:
-    A tf.keras.model which accepts a 256x256x2 tensor and compares it to a
-    target 256x256x1 tensor.
-  """
-    initializer = tf.random_normal_initializer(0., 0.02)
-
-    input_img = tf.keras.layers.Input(shape=[256, 256, 2], name='input_image')
-    target_img = tf.keras.layers.Input(shape=[256, 256, 1],
-                                       name='target_image')
-
-    x = tf.keras.layers.concatenate([input_img,
-                                     target_img])  # (bs, 256, 256, channels*2)
-
-    down1 = _downsample(64, 4, False)(x)  # (bs, 128, 128, 64)
-    down2 = _downsample(128, 4)(down1)  # (bs, 64, 64, 128)
-    down3 = _downsample(256, 4)(down2)  # (bs, 32, 32, 256)
-
-    zero_pad1 = tf.keras.layers.ZeroPadding2D()(down3)  # (bs, 34, 34, 256)
-    conv = tf.keras.layers.Conv2D(512,
-                                  4,
-                                  strides=1,
-                                  kernel_initializer=initializer,
-                                  use_bias=False)(
-                                      zero_pad1)  # (bs, 31, 31, 512)
-
-    batchnorm1 = tf.keras.layers.BatchNormalization()(conv)
-
-    leaky_relu = tf.keras.layers.LeakyReLU()(batchnorm1)
-
-    zero_pad2 = tf.keras.layers.ZeroPadding2D()(
-        leaky_relu)  # (bs, 33, 33, 512)
-
-    last = tf.keras.layers.Conv2D(1,
-                                  4,
-                                  strides=1,
-                                  kernel_initializer=initializer)(
-                                      zero_pad2)  # (bs, 30, 30, 1)
-
-    return tf.keras.Model(inputs=[input_img, target_img], outputs=last)
-
-
 def generate_images(model: tf.keras.Model, inputs: List[tf.Tensor],
                     target: tf.Tensor) -> None:
     """In Colab, prints [ inputs... | real(a,b) | predicted(a,b)] to the display.
@@ -273,23 +165,7 @@ def generate_images(model: tf.keras.Model, inputs: List[tf.Tensor],
 
 
 class Model():
-    def Build(train_ds: tf.data.Dataset, test_ds: tf.data.Dataset, epochs: int,
-              num_cells: int) -> "Model":
-        generator = _make_generator()
-        generator_optimizer = tf.keras.optimizers.Adam(2e-4, beta_1=0.5)
-        discriminator = _make_discriminator()
-        discriminator_optimizer = tf.keras.optimizers.Adam(2e-4, beta_1=0.5)
-        loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)
-        return Model(generator, generator_optimizer, discriminator,
-                     discriminator_optimizer, loss_object, train_ds, test_ds,
-                     epochs, num_cells)
-
     def __init__(self,
-                 generator: tf.keras.Model,
-                 generator_optimizer: tf.keras.optimizers.Optimizer,
-                 discriminator: tf.keras.Model,
-                 discriminator_optimizer: tf.keras.optimizers.Optimizer,
-                 loss_object: tf.keras.losses.Loss,
                  train_ds: tf.data.Dataset,
                  test_ds: tf.data.Dataset,
                  epochs: int,
@@ -298,21 +174,131 @@ class Model():
                  checkpoint: Optional[tf.train.Checkpoint] = None,
                  checkpoint_prefix: Optional[Text] = None,
                  summary_writer: tf.summary.SummaryWriter = None):
-        # public
-        self.generator = generator
-        # private
-        self._generator_optimizer = generator_optimizer
-        self._discriminator = discriminator
-        self._discriminator_optimizer = discriminator_optimizer
-        self._loss_object = loss_object
+        self._num_cells = num_cells
+        self._num_inputs = self._num_cells - 1
+
+        self.generator = self._make_generator()
+        self._generator_optimizer = tf.keras.optimizers.Adam(2e-4, beta_1=0.5)
+        self._discriminator = self._make_discriminator()
+        self._discriminator_optimizer = tf.keras.optimizers.Adam(2e-4,
+                                                                 beta_1=0.5)
+        self._loss_object = tf.keras.losses.BinaryCrossentropy(
+            from_logits=True)
         self._train_ds = train_ds
         self._test_ds = test_ds
         self._epochs = epochs
-        self._num_cells = num_cells
         self._lambda = lambda_arg
         self._checkpoint = checkpoint
         self._checkpoint_prefix = checkpoint_prefix
         self._summary_writer = summary_writer
+
+    def _make_generator(self) -> tf.keras.Model:
+        """Creates a generator.
+
+        99% of this is copied directly from
+        https://www.tensorflow.org/tutorials/generative/pix2pix#build_the_generator,
+        except for the input shape (now two channels, two greyscale images instead of
+        one RGB image) and output shape (one channel, one greyscale image instead of
+        one RGB image).
+
+        Returns:
+          a tf.keras.Model which returns a 256x256x1 tensor.
+        """
+        inputs = tf.keras.layers.Input(shape=[256, 256, self._num_inputs])
+
+        up_stack = [
+            _upsample(512, 4, apply_dropout=True),  # (bs, 2, 2, 1024)
+            _upsample(512, 4, apply_dropout=True),  # (bs, 4, 4, 1024)
+            _upsample(512, 4, apply_dropout=True),  # (bs, 8, 8, 1024)
+            _upsample(512, 4),  # (bs, 16, 16, 1024)
+            _upsample(256, 4),  # (bs, 32, 32, 512)
+            _upsample(128, 4),  # (bs, 64, 64, 256)
+            _upsample(64, 4),  # (bs, 128, 128, 128)
+        ]
+
+        x = inputs
+
+        skips = []
+        for down in [
+                _downsample(64, 4,
+                            apply_batchnorm=False),  # (bs, 128, 128, 64)
+                _downsample(128, 4),  # (bs, 64, 64, 128)
+                _downsample(256, 4),  # (bs, 32, 32, 256)
+                _downsample(512, 4),  # (bs, 16, 16, 512)
+                _downsample(512, 4),  # (bs, 8, 8, 512)
+                _downsample(512, 4),  # (bs, 4, 4, 512)
+                _downsample(512, 4),  # (bs, 2, 2, 512)
+                _downsample(512, 4),  # (bs, 1, 1, 512)
+        ]:
+            x = down(x)
+            skips.append(x)
+
+        skips = reversed(skips[:-1])
+
+        # Upsampling and establishing the skip connections
+        for up, skip in zip(up_stack, skips):
+            x = up(x)
+            x = tf.keras.layers.Concatenate()([x, skip])
+
+        last = tf.keras.layers.Conv2DTranspose(
+            1,  # one output channel, i.e. greyscale
+            4,
+            strides=2,
+            padding='same',
+            kernel_initializer=tf.random_normal_initializer(0., 0.02),
+            activation='tanh')  # (bs, 256, 256, 3)
+
+        x = last(x)
+
+        return tf.keras.Model(inputs=inputs, outputs=x)
+
+    def _make_discriminator(self) -> tf.keras.Model:
+        """Returns a discriminator.
+
+        This is 99% the same as
+        https://www.tensorflow.org/tutorials/generative/pix2pix#build_the_discriminator,
+        except that the shape of the input and output tensors are different.
+
+        Returns:
+          A tf.keras.model which accepts a 256x256x2 tensor and compares it to a
+          target 256x256x1 tensor.
+        """
+        initializer = tf.random_normal_initializer(0., 0.02)
+
+        input_img = tf.keras.layers.Input(shape=[256, 256, self._num_inputs],
+                                          name='input_image')
+        target_img = tf.keras.layers.Input(shape=[256, 256, 1],
+                                           name='target_image')
+
+        x = tf.keras.layers.concatenate([input_img, target_img
+                                         ])  # (bs, 256, 256, channels*2)
+
+        down1 = _downsample(64, 4, False)(x)  # (bs, 128, 128, 64)
+        down2 = _downsample(128, 4)(down1)  # (bs, 64, 64, 128)
+        down3 = _downsample(256, 4)(down2)  # (bs, 32, 32, 256)
+
+        zero_pad1 = tf.keras.layers.ZeroPadding2D()(down3)  # (bs, 34, 34, 256)
+        conv = tf.keras.layers.Conv2D(512,
+                                      4,
+                                      strides=1,
+                                      kernel_initializer=initializer,
+                                      use_bias=False)(
+                                          zero_pad1)  # (bs, 31, 31, 512)
+
+        batchnorm1 = tf.keras.layers.BatchNormalization()(conv)
+
+        leaky_relu = tf.keras.layers.LeakyReLU()(batchnorm1)
+
+        zero_pad2 = tf.keras.layers.ZeroPadding2D()(
+            leaky_relu)  # (bs, 33, 33, 512)
+
+        last = tf.keras.layers.Conv2D(1,
+                                      4,
+                                      strides=1,
+                                      kernel_initializer=initializer)(
+                                          zero_pad2)  # (bs, 30, 30, 1)
+
+        return tf.keras.Model(inputs=[input_img, target_img], outputs=last)
 
     def _generator_loss(self, disc_generated_output, gen_output, target):
         gan_loss = self._loss_object(tf.ones_like(disc_generated_output),

--- a/src/model_test.py
+++ b/src/model_test.py
@@ -71,8 +71,41 @@ class TrainTestClass(googletest.TestCase):
         with tempfile.NamedTemporaryFile(mode='w+', suffix=".png") as tmp_file:
             # We can't assert anything about the generated image, but we just
             # want to see that imageutils.predict(generator, ...) doesn't fail.
-            imageutils.predict(model.generator, _PATH_TO_FONT, '市', '來',
-                               tmp_file.name)
+            imageutils.predict(model.generator, _PATH_TO_FONT, [
+                '市',
+                '來',
+            ], tmp_file.name)
+
+        # We want to see that model_lib.generate_images(generator, ...) doesn't
+        # fail.
+        for items in test_dataset.take(1):
+            inputs = items[:-1]
+            target = items[-1]
+            model_lib.generate_images(model.generator, inputs, target)
+
+    def test_train_one_epoch_split_3(self):
+        num_cells = 4
+        train_dataset, test_dataset = model_lib.make_datasets(
+            'src/testutils/corpus/split-3/0-*.png', num_cells)
+
+        model = model_lib.Model(train_dataset,
+                                test_dataset,
+                                epochs=1,
+                                num_cells=num_cells)
+        model.fit()
+
+        self.assertEqual(model.generator.input_shape, (None, 256, 256, 3))
+        self.assertEqual(model.generator.output_shape, (None, 256, 256, 1))
+        self.assertFalse(model.generator.run_eagerly)
+
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".png") as tmp_file:
+            # We can't assert anything about the generated image, but we just
+            # want to see that imageutils.predict(generator, ...) doesn't fail.
+            imageutils.predict(model.generator, _PATH_TO_FONT, [
+                '市',
+                '口',
+                '來',
+            ], tmp_file.name)
 
         # We want to see that model_lib.generate_images(generator, ...) doesn't
         # fail.

--- a/src/model_test.py
+++ b/src/model_test.py
@@ -54,13 +54,14 @@ class TestClass(googletest.TestCase):
 
 class TrainTestClass(googletest.TestCase):
     def test_train_one_epoch(self):
+        num_cells = 3
         train_dataset, test_dataset = model_lib.make_datasets(
-            'src/testutils/corpus/split-1/0-*.png', num_cells=3)
+            'src/testutils/corpus/split-1/0-*.png', num_cells)
 
-        model = model_lib.Model.Build(train_dataset,
-                                      test_dataset,
-                                      epochs=1,
-                                      num_cells=3)
+        model = model_lib.Model(train_dataset,
+                                test_dataset,
+                                epochs=1,
+                                num_cells=num_cells)
         model.fit()
 
         self.assertEqual(model.generator.input_shape, (None, 256, 256, 2))


### PR DESCRIPTION
 Add new test_train_one_epoch_split_3 test case for arbitrary-input generators. Also modify imageutils methods to accept lists of inputs. This works towards https://github.com/google/autocjk/issues/22.